### PR TITLE
feat: implement province filter

### DIFF
--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/DataScreen.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/DataScreen.kt
@@ -1,34 +1,711 @@
 package com.app.covidpredict.ui.screen
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.text.SimpleDateFormat
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.app.covidpredict.R
+import com.app.covidpredict.theme.CovidPredictTheme
 import com.app.covidpredict.viewmodels.DataViewModel
+import com.app.covidpredict.viewmodels.HistoryData
 import com.app.covidpredict.viewmodels.SharedViewModel
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DataScreen(
     viewModel: DataViewModel,
     sharedViewModel: SharedViewModel
 ) {
-    val data by viewModel.dataList.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val selectedLocation by sharedViewModel.selectedLocation.collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Data Wilayah")
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF8FBFE)),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        item {
+            DataHeader()
+        }
 
-        data.forEach {
-            Button(onClick = {
-                sharedViewModel.setWilayah(it)
-            }) {
-                Text(it)
+        item {
+            DataSearchBar(
+                query = uiState.searchQuery,
+                onQueryChange = { viewModel.onSearchQueryChange(it) }
+            )
+        }
+
+        item {
+            FilterSection(
+                selectedLocation = selectedLocation,
+                locations = sharedViewModel.locations,
+                selectedFilter = uiState.selectedFilter,
+                onLocationChange = { sharedViewModel.updateLocation(it) },
+                onFilterChange = { viewModel.onFilterChange(it) }
+            )
+        }
+
+        item {
+            NationalOverviewCard(
+                avgCases = uiState.avgDailyCases,
+                recoveryRate = uiState.recoveryRate,
+                location = selectedLocation
+            )
+        }
+
+        item {
+            HistorySectionHeader()
+        }
+
+        stickyHeader {
+            TableHeader()
+        }
+
+        items(uiState.filteredHistoryList) { data ->
+            DataRecordRow(data)
+        }
+
+        item {
+            DataLoadingFooter()
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+fun DataHeader() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = "Data Historis",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.ExtraBold,
+            color = Color(0xFF021F29)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Surface(
+            color = Color(0xFFD7F2DE),
+            shape = RoundedCornerShape(20.dp)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF126D27))
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Siaran Langsung",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color(0xFF126D27),
+                    fontWeight = FontWeight.ExtraBold
+                )
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit
+) {
+    TextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = Modifier.fillMaxWidth(),
+        placeholder = {
+            Text(
+                text = "Cari berdasarkan tanggal atau data...",
+                color = Color.Gray,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = Color.Gray,
+                modifier = Modifier.size(24.dp)
+            )
+        },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = Color(0xFFEBF6FF),
+            unfocusedContainerColor = Color(0xFFEBF6FF),
+            disabledContainerColor = Color(0xFFEBF6FF),
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+        ),
+        shape = RoundedCornerShape(12.dp),
+        singleLine = true
+    )
+}
+
+@Composable
+fun FilterSection(
+    selectedLocation: String,
+    locations: List<String>,
+    selectedFilter: String,
+    onLocationChange: (String) -> Unit,
+    onFilterChange: (String) -> Unit
+) {
+    var showFilterMenu by remember { mutableStateOf(false) }
+    var showLocationMenu by remember { mutableStateOf(false) }
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    val filterOptions = listOf("7 Hari Terakhir", "30 Hari Terakhir", "Custom")
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.weight(1.2f)) {
+            Button(
+                onClick = { showLocationMenu = true },
+                modifier = Modifier.fillMaxWidth().height(40.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF005EA4)),
+                shape = RoundedCornerShape(8.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.map),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(selectedLocation, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+
+            DropdownMenu(
+                expanded = showLocationMenu,
+                onDismissRequest = { showLocationMenu = false }
+            ) {
+                locations.forEach { location ->
+                    DropdownMenuItem(
+                        text = { Text(location) },
+                        onClick = {
+                            showLocationMenu = false
+                            onLocationChange(location)
+                        }
+                    )
+                }
+            }
+        }
+
+        Surface(
+            modifier = Modifier.weight(1.3f).height(40.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color(0xFFCDE8F9)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.calender),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = Color(0xFF005EA4)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    selectedFilter,
+                    color = Color(0xFF005EA4),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1
+                )
+            }
+        }
+
+        Box {
+            Surface(
+                modifier = Modifier.size(40.dp).clickable { showFilterMenu = true },
+                shape = RoundedCornerShape(8.dp),
+                color = Color(0xFFCDE8F9)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.filter),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = Color(0xFF005EA4)
+                    )
+                }
+            }
+
+            DropdownMenu(
+                expanded = showFilterMenu,
+                onDismissRequest = { showFilterMenu = false }
+            ) {
+                filterOptions.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option) },
+                        onClick = {
+                            showFilterMenu = false
+                            if (option == "Custom") {
+                                showDatePicker = true
+                            } else {
+                                onFilterChange(option)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        CustomDateRangePicker(
+            onDismiss = { showDatePicker = false },
+            onDateSelected = { start, end ->
+                onFilterChange("$start - $end")
+                showDatePicker = false
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomDateRangePicker(
+    onDismiss: () -> Unit,
+    onDateSelected: (String, String) -> Unit
+) {
+    // Gunakan UTC timezone agar sinkron dengan DateRangePicker Material 3
+    val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+        set(Calendar.DAY_OF_MONTH, 1)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+
+    var displayedMonthMillis by remember { mutableLongStateOf(calendar.timeInMillis) }
+    var selectedStartDate by remember { mutableStateOf<Long?>(null) }
+    var selectedEndDate by remember { mutableStateOf<Long?>(null) }
+
+    val months = listOf("Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember")
+    val years = (2020..2030).map { it.toString() }
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (selectedStartDate != null && selectedEndDate != null) {
+                        onDateSelected(
+                            convertMillisToDate(selectedStartDate!!),
+                            convertMillisToDate(selectedEndDate!!)
+                        )
+                    }
+                },
+                enabled = selectedStartDate != null && selectedEndDate != null
+            ) {
+                Text("Simpan", fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Batal")
+            }
+        }
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            // --- Custom Headline ---
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = "Pilih Rentang Tanggal",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = if (selectedStartDate != null && selectedEndDate != null) {
+                        "${formatDateUI(selectedStartDate!!)} - ${formatDateUI(selectedEndDate!!)}"
+                    } else {
+                        "Mulai - Selesai"
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            HorizontalDivider()
+
+            key(displayedMonthMillis) {
+                val dateRangePickerState = rememberDateRangePickerState(
+                    initialDisplayedMonthMillis = displayedMonthMillis,
+                    initialSelectedStartDateMillis = selectedStartDate,
+                    initialSelectedEndDateMillis = selectedEndDate
+                )
+
+                LaunchedEffect(dateRangePickerState.selectedStartDateMillis, dateRangePickerState.selectedEndDateMillis) {
+                    selectedStartDate = dateRangePickerState.selectedStartDateMillis
+                    selectedEndDate = dateRangePickerState.selectedEndDateMillis
+                }
+
+                val currentCal = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+                    timeInMillis = dateRangePickerState.displayedMonthMillis
+                }
+
+                // --- Dropdown Selector UI ---
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    var monthExpanded by remember { mutableStateOf(false) }
+                    var yearExpanded by remember { mutableStateOf(false) }
+
+                    // Month Dropdown
+                    ExposedDropdownMenuBox(
+                        expanded = monthExpanded,
+                        onExpandedChange = { monthExpanded = it },
+                        modifier = Modifier.weight(1.2f)
+                    ) {
+                        OutlinedTextField(
+                            value = months[currentCal.get(Calendar.MONTH)],
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = monthExpanded) },
+                            modifier = Modifier.menuAnchor(),
+                            shape = RoundedCornerShape(8.dp),
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            singleLine = true
+                        )
+                        ExposedDropdownMenu(
+                            expanded = monthExpanded,
+                            onDismissRequest = { monthExpanded = false }
+                        ) {
+                            months.forEachIndexed { index, name ->
+                                DropdownMenuItem(
+                                    text = { Text(name, style = MaterialTheme.typography.bodySmall) },
+                                    onClick = {
+                                        currentCal.set(Calendar.MONTH, index)
+                                        displayedMonthMillis = currentCal.timeInMillis
+                                        monthExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    // Year Dropdown
+                    ExposedDropdownMenuBox(
+                        expanded = yearExpanded,
+                        onExpandedChange = { yearExpanded = it },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        OutlinedTextField(
+                            value = currentCal.get(Calendar.YEAR).toString(),
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = yearExpanded) },
+                            modifier = Modifier.menuAnchor(),
+                            shape = RoundedCornerShape(8.dp),
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            singleLine = true
+                        )
+                        ExposedDropdownMenu(
+                            expanded = yearExpanded,
+                            onDismissRequest = { yearExpanded = false }
+                        ) {
+                            years.forEach { yearStr ->
+                                DropdownMenuItem(
+                                    text = { Text(yearStr, style = MaterialTheme.typography.bodySmall) },
+                                    onClick = {
+                                        currentCal.set(Calendar.YEAR, yearStr.toInt())
+                                        displayedMonthMillis = currentCal.timeInMillis
+                                        yearExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                DateRangePicker(
+                    state = dateRangePickerState,
+                    modifier = Modifier.height(340.dp),
+                    showModeToggle = false,
+                    title = null,
+                    headline = null
+                )
+            }
+        }
+    }
+}
+
+// Fungsi helper untuk UI
+fun formatDateUI(millis: Long): String {
+    val formatter = SimpleDateFormat("dd MMM yyyy", Locale("id", "ID"))
+    formatter.timeZone = TimeZone.getTimeZone("UTC") // Sangat penting agar tanggal tidak meleset 1 hari
+    return formatter.format(Date(millis))
+}
+
+private fun convertMillisToDate(millis: Long): String {
+    val formatter = SimpleDateFormat("dd/MM/yy", Locale.getDefault())
+    return formatter.format(Date(millis))
+}
+
+@Composable
+fun NationalOverviewCard(avgCases: String, recoveryRate: String, location: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text(
+                        "WAWASAN WILAYAH",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.Gray,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Ikhtisar $location",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = Color(0xFF021F29)
+                    )
+                }
+                Icon(
+                    painter = painterResource(id = R.drawable.prediksi),
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = Color(0xFF005EA4)
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Surface(
+                    modifier = Modifier.weight(1f),
+                    color = Color(0xFFEBF6FF),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            "RATA-RATA KASUS\nHARIAN",
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = Color.Gray,
+                            lineHeight = 12.sp
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            avgCases,
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = Color(0xFF021F29)
+                        )
+                    }
+                }
+                Surface(
+                    modifier = Modifier.weight(1f),
+                    color = Color(0xFFEBF6FF),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            "TINGKAT\nKESEMBUHAN",
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = Color.Gray,
+                            lineHeight = 12.sp
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            recoveryRate,
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = Color(0xFF126D27)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HistorySectionHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            "RIWAYAT DATA",
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.Gray,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            "Ekspor CSV",
+            style = MaterialTheme.typography.labelLarge,
+            color = Color(0xFF005EA4),
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+fun DataRecordRow(data: HistoryData) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(data.date, modifier = Modifier.weight(1.3f), fontSize = 12.sp, fontWeight = FontWeight.Bold, color = Color(0xFF021F29))
+            Text(data.positive, modifier = Modifier.weight(1f), fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, color = Color(0xFF021F29))
+            Text(data.recovered, modifier = Modifier.weight(1f), fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, color = Color(0xFF126D27))
+            Text(data.deaths, modifier = Modifier.weight(1f), fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, color = Color(0xFFB02528))
+        }
+    }
+}
+
+@Composable
+fun TableHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFF8FBFE))
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text("TANGGAL", modifier = Modifier.weight(1.3f), fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, color = Color.Gray)
+        Text("POSITIF", modifier = Modifier.weight(1f), fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, color = Color.Gray)
+        Text("SEMBUH", modifier = Modifier.weight(1f), fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, color = Color.Gray)
+        Text("MENINGGAL", modifier = Modifier.weight(1f), fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, color = Color.Gray)
+    }
+}
+
+fun Modifier.shimmerEffect(): Modifier = composed {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val startOffsetX by transition.animateFloat(
+        initialValue = -2 * size.width.toFloat(),
+        targetValue = 2 * size.width.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000)
+        ),
+        label = "shimmer"
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                Color(0xFFEBEBF4),
+                Color(0xFFDEDEE7),
+                Color(0xFFEBEBF4),
+            ),
+            start = Offset(startOffsetX, 0f),
+            end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
+        )
+    )
+        .onGloballyPositioned {
+            size = it.size
+        }
+}
+
+@Composable
+fun DataLoadingFooter() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        repeat(3) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
+                    .shimmerEffect(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+            ) {}
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Mengambil data historis...",
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            color = Color.Gray,
+            style = MaterialTheme.typography.labelMedium
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DataScreenPreview() {
+    CovidPredictTheme {
+        DataScreen(
+            viewModel = DataViewModel(),
+            sharedViewModel = SharedViewModel()
+        )
     }
 }

--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/DataViewModel.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/DataViewModel.kt
@@ -3,10 +3,75 @@ package com.app.covidpredict.viewmodels
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class HistoryData(
+    val date: String,
+    val positive: String,
+    val recovered: String,
+    val deaths: String
+)
+
+data class DataUiState(
+    val lastUpdated: String = "14 Okt 2023, 08:32 AM",
+    val avgDailyCases: String = "12,482",
+    val recoveryRate: String = "94.2%",
+    val historyList: List<HistoryData> = listOf(
+        HistoryData("Oct 24, 2023", "14,201", "13,105", "92"),
+        HistoryData("Oct 23, 2023", "12,894", "11,942", "84"),
+        HistoryData("Oct 22, 2023", "15,042", "14,220", "112"),
+        HistoryData("Oct 21, 2023", "11,203", "10,800", "76"),
+        HistoryData("Oct 20, 2023", "13,556", "12,980", "89"),
+        HistoryData("Oct 19, 2023", "14,110", "13,400", "95"),
+        HistoryData("Oct 18, 2023", "12,110", "11,400", "75"),
+        HistoryData("Oct 17, 2023", "11,510", "10,200", "65"),
+        HistoryData("Oct 16, 2023", "10,110", "9,400", "55"),
+        HistoryData("Oct 15, 2023", "9,110", "8,400", "45")
+    ),
+    val filteredHistoryList: List<HistoryData> = emptyList(),
+    val isLoading: Boolean = false,
+    val searchQuery: String = "",
+    val selectedFilter: String = "30 Hari Terakhir"
+)
 
 class DataViewModel : ViewModel() {
-    private val _dataList = MutableStateFlow(
-        listOf("Jawa Timur", "DKI Jakarta", "Jawa Barat")
-    )
-    val dataList: StateFlow<List<String>> = _dataList
+    private val _uiState = MutableStateFlow(DataUiState())
+    val uiState: StateFlow<DataUiState> = _uiState.asStateFlow()
+
+    init {
+        updateFilteredList()
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _uiState.value = _uiState.value.copy(searchQuery = query)
+        updateFilteredList()
+    }
+
+    fun onFilterChange(filter: String) {
+        _uiState.value = _uiState.value.copy(selectedFilter = filter)
+        updateFilteredList()
+    }
+
+    private fun updateFilteredList() {
+        val state = _uiState.value
+
+        // Mock filtering by date range
+        var filtered = when (state.selectedFilter) {
+            "7 Hari Terakhir" -> state.historyList.take(7)
+            "30 Hari Terakhir" -> state.historyList // Assuming 30 days is the whole list for this demo
+            else -> state.historyList // For custom range, we just show all in this demo
+        }
+
+        // Search filtering
+        if (state.searchQuery.isNotEmpty()) {
+            filtered = filtered.filter {
+                it.date.contains(state.searchQuery, ignoreCase = true) ||
+                        it.positive.contains(state.searchQuery) ||
+                        it.recovered.contains(state.searchQuery) ||
+                        it.deaths.contains(state.searchQuery)
+            }
+        }
+
+        _uiState.value = state.copy(filteredHistoryList = filtered)
+    }
 }

--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/SharedViewModel.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/SharedViewModel.kt
@@ -1,12 +1,37 @@
 package com.app.covidpredict.viewmodels
 
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class SharedViewModel : ViewModel() {
-    var selectedWilayah = mutableStateOf("Nasional")
 
-    fun setWilayah(wilayah: String) {
-        selectedWilayah.value = wilayah
+    private val _selectedLocation = MutableStateFlow("Nasional")
+    val selectedLocation: StateFlow<String> = _selectedLocation.asStateFlow()
+
+    // 🔥 list untuk UI
+    val locations = listOf(
+        "Nasional", "Aceh", "Bali", "Banten", "Bengkulu", "DKI Jakarta",
+        "Daerah Istimewa Yogyakarta", "Gorontalo", "Jambi", "Jawa Barat",
+        "Jawa Tengah", "Jawa Timur", "Kalimantan Barat", "Kalimantan Selatan",
+        "Kalimantan Tengah", "Kalimantan Timur", "Kalimantan Utara",
+        "Kepulauan Bangka Belitung", "Kepulauan Riau", "Lampung", "Maluku",
+        "Maluku Utara", "Nusa Tenggara Barat", "Nusa Tenggara Timur",
+        "Papua", "Papua Barat", "Riau", "Sulawesi Barat", "Sulawesi Selatan",
+        "Sulawesi Tengah", "Sulawesi Tenggara", "Sulawesi Utara",
+        "Sumatera Barat", "Sumatera Selatan", "Sumatera Utara"
+    )
+
+    fun updateLocation(location: String) {
+        _selectedLocation.value = location
+    }
+
+    fun getApiLocation(): String {
+        return if (_selectedLocation.value == "Nasional") {
+            "Indonesia"
+        } else {
+            _selectedLocation.value
+        }
     }
 }

--- a/frontend/android-app/app/src/main/res/drawable/calender.xml
+++ b/frontend/android-app/app/src/main/res/drawable/calender.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="20" android:viewportWidth="20" android:width="24dp">
+      
+    <path android:fillColor="#000000" android:pathData="M1,4c0,-1.1 0.9,-2 2,-2h14a2,2 0,0 1,2 2v14a2,2 0,0 1,-2 2L3,20a2,2 0,0 1,-2 -2L1,4zM3,6v12h14L17,6L3,6zM5,0h2v2L5,2L5,0zM13,0h2v2h-2L13,0zM5,9h2v2L5,11L5,9zM5,13h2v2L5,15v-2zM9,9h2v2L9,11L9,9zM9,13h2v2L9,15v-2zM13,9h2v2h-2L13,9zM13,13h2v2h-2v-2z"/>
+    
+</vector>

--- a/frontend/android-app/app/src/main/res/drawable/filter.xml
+++ b/frontend/android-app/app/src/main/res/drawable/filter.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="#FF000000" android:pathData="M24,3c0,0.55 -0.45,1 -1,1L1,4c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1L23,2c0.55,0 1,0.45 1,1ZM15,20h-6c-0.55,0 -1,0.45 -1,1s0.45,1 1,1h6c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1ZM19,11L5,11c-0.55,0 -1,0.45 -1,1s0.45,1 1,1h14c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1Z"/>
+    
+</vector>


### PR DESCRIPTION
## Deskripsi

Implementasi Data Screen untuk menampilkan data historis, filter provinsi, pencarian data, serta filter rentang waktu.

## Perubahan yang dilakukan:

- Membuat tampilan Data Screen untuk menampilkan halaman Data Historis.
- Menambahkan search bar untuk mencari data berdasarkan tanggal, jumlah positif, sembuh, atau meninggal.
- Menambahkan filter lokasi/provinsi menggunakan SharedViewModel.
- Menambahkan filter rentang waktu 7 Hari Terakhir, 30 Hari Terakhir, dan Custom.
- Menambahkan custom date range picker untuk memilih rentang tanggal secara manual.
- Menambahkan kartu Wawasan Wilayah yang menampilkan rata-rata kasus harian dan tingkat kesembuhan.
- Menambahkan tabel Riwayat Data berisi tanggal, positif, sembuh, dan meninggal.
- Menambahkan shimmer loading footer sebagai indikator pengambilan data.
- Membuat DataViewModel untuk mengelola state data historis, search query, dan filter tanggal.
- Membuat SharedViewModel untuk menyimpan pilihan lokasi agar dapat digunakan bersama oleh screen lain.
- Menambahkan icon kalender dan filter untuk kebutuhan tampilan Data Screen.

## Catatan:

- Data pada DataViewModel masih menggunakan mock data.
- Filter provinsi sudah dapat mengubah lokasi yang dipilih pada UI.
- Filter tanggal dan pencarian data sudah terhubung dengan state DataViewModel.