### PR TITLE
feat: create prediction page

### DIFF
--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/GrafikScreen.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/GrafikScreen.kt
@@ -1,25 +1,419 @@
 package com.app.covidpredict.ui.screen
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.app.covidpredict.R
+import com.app.covidpredict.theme.CovidPredictTheme
+import com.app.covidpredict.viewmodels.ChartPoint
 import com.app.covidpredict.viewmodels.GrafikViewModel
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottomAxis
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
+import com.patrykandpatrick.vico.compose.common.component.rememberShapeComponent
+import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
+import com.patrykandpatrick.vico.compose.common.of
+import com.patrykandpatrick.vico.compose.common.shader.color
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
+import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarkerVisibilityListener
+import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
+import com.patrykandpatrick.vico.core.common.Dimensions
+import com.patrykandpatrick.vico.core.common.component.LineComponent
+import com.patrykandpatrick.vico.core.common.shape.Shape
+import com.patrykandpatrick.vico.core.common.shader.DynamicShader
 
 @Composable
 fun GrafikScreen(viewModel: GrafikViewModel) {
-    val data by viewModel.grafikData.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Grafik (Dummy)")
-
-        data.forEach {
-            Text("Value: $it")
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF8FBFE)),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            GrafikHeaderSection()
         }
+
+        item {
+            FilterAndRegionRow(
+                selectedTab = uiState.selectedTab,
+                selectedRegion = uiState.selectedRegion,
+                regions = uiState.regions,
+                onTabSelected = { viewModel.selectTab(it) },
+                onRegionSelected = { viewModel.selectRegion(it) }
+            )
+        }
+
+        item {
+            CaseTrajectoryCard(
+                avgError = uiState.avgError,
+                chartData = uiState.chartData
+            )
+        }
+
+        item {
+            Text(
+                text = "Dibandingkan minggu sebelumnya",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF021F29)
+            )
+        }
+
+        item {
+            ModelInsightCard(
+                title = uiState.insightTitle,
+                content = uiState.insightText
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+fun GrafikHeaderSection() {
+    Column {
+        Text(
+            text = "EPIDEMIOLOGICAL ANALYSIS",
+            style = MaterialTheme.typography.labelMedium,
+            color = Color(0xFF005EA4),
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.sp
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Akurasi Model & Prediksi Tren",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.ExtraBold,
+            color = Color(0xFF021F29)
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = "Membandingkan data kasus regional yang dilaporkan dengan hasil probabilistik jaringan saraf kami untuk siklus orbital berikutnya.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.Gray,
+            lineHeight = 20.sp
+        )
+    }
+}
+
+@Composable
+fun FilterAndRegionRow(
+    selectedTab: Int,
+    selectedRegion: String,
+    regions: List<String>,
+    onTabSelected: (Int) -> Unit,
+    onRegionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Tab Switcher
+        Surface(
+            modifier = Modifier.weight(1f),
+            shape = RoundedCornerShape(12.dp),
+            color = Color(0xFFEBF6FF)
+        ) {
+            Row(modifier = Modifier.padding(4.dp)) {
+                val tabs = listOf("Harian", "Mingguan", "Bulanan")
+                tabs.forEachIndexed { index, title ->
+                    val isSelected = selectedTab == index
+                    Button(
+                        onClick = { onTabSelected(index) },
+                        modifier = Modifier.weight(1f).height(36.dp),
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isSelected) Color(0xFF005EA4) else Color.Transparent,
+                            contentColor = if (isSelected) Color.White else Color.Gray
+                        ),
+                        contentPadding = PaddingValues(0.dp),
+                        elevation = null
+                    ) {
+                        Text(text = title, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Filter Icon
+        Icon(
+            painter = painterResource(id = R.drawable.filter),
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = Color(0xFF005EA4).copy(alpha = 0.7f)
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        // Region Text with Dropdown
+        Box {
+            Column(
+                modifier = Modifier.clickable { expanded = true },
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text("Wilayah:", fontSize = 10.sp, color = Color.Gray, fontWeight = FontWeight.Bold)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        selectedRegion,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF005EA4)
+                    )
+                    Icon(
+                        painter = painterResource(id = R.drawable.dropdown),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = Color(0xFF005EA4)
+                    )
+                }
+            }
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                regions.forEach { region ->
+                    DropdownMenuItem(
+                        text = { Text(region) },
+                        onClick = {
+                            onRegionSelected(region)
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CaseTrajectoryCard(avgError: String, chartData: List<ChartPoint>) {
+    val modelProducer = remember { CartesianChartModelProducer() }
+    val marker = rememberMarker()
+    val haptic = LocalHapticFeedback.current
+
+    LaunchedEffect(chartData) {
+        if (chartData.isNotEmpty()) {
+            modelProducer.runTransaction {
+                lineSeries {
+                    series(chartData.map { it.actual })
+                    series(chartData.map { it.prediction })
+                }
+            }
+        }
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Column {
+                    Text(
+                        "Lintasan Kasus",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = Color(0xFF021F29)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(modifier = Modifier.size(12.dp).clip(CircleShape).background(Color(0xFF005EA4)))
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text("Kasus Aktual", style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+                        Spacer(modifier = Modifier.width(20.dp))
+                        Box(
+                            modifier = Modifier
+                                .size(12.dp)
+                                .clip(CircleShape)
+                                .background(Color(0xFF81C784).copy(alpha = 0.2f))
+                                .padding(2.dp)
+                                .clip(CircleShape)
+                                .background(Color(0xFF81C784))
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text("Kasus Prediksi", style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+                    }
+                }
+
+                Column(horizontalAlignment = Alignment.End) {
+                    Text("RATA-RATA ERROR", fontSize = 9.sp, fontWeight = FontWeight.Bold, color = Color.Gray)
+                    Text(avgError, fontSize = 24.sp, fontWeight = FontWeight.ExtraBold, color = Color(0xFF126D27))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Chart Visualization
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(240.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                val scrollState = rememberVicoScrollState(scrollEnabled = false)
+                CartesianChartHost(
+                    chart = rememberCartesianChart(
+                        rememberLineCartesianLayer(
+                            lines = listOf(
+                                remember {
+                                    LineCartesianLayer.LineSpec(
+                                        shader = DynamicShader.color(Color(0xFF005EA4)),
+                                        thicknessDp = 2f
+                                    )
+                                },
+                                remember {
+                                    LineCartesianLayer.LineSpec(
+                                        shader = DynamicShader.color(Color(0xFF81C784)),
+                                        thicknessDp = 2f
+                                    )
+                                },
+                            ),
+                        ),
+                        bottomAxis = rememberBottomAxis(
+                            labelRotationDegrees = 0f,
+                            valueFormatter = { x, _, _ -> chartData.getOrNull(x.toInt())?.label ?: "" }
+                        ),
+                    ),
+                    modelProducer = modelProducer,
+                    marker = marker,
+                    markerVisibilityListener = object : CartesianMarkerVisibilityListener {
+                        override fun onShown(
+                            marker: CartesianMarker,
+                            targets: List<CartesianMarker.Target>,
+                        ) {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        }
+
+                        override fun onMoved(
+                            marker: CartesianMarker,
+                            targets: List<CartesianMarker.Target>,
+                        ) {
+                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        }
+
+                        override fun onHidden(marker: CartesianMarker) {}
+                    },
+                    scrollState = scrollState,
+                    runInitialAnimation = true,
+                    diffAnimationSpec = tween(durationMillis = 1000),
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun rememberMarker(): CartesianMarker {
+    val label = rememberTextComponent(
+        color = Color.Black,
+        background = rememberShapeComponent(
+            shape = Shape.Rectangle,
+            color = Color.White,
+        ).apply {
+            setShadow(radius = 4f, dy = 2f)
+        },
+        padding = Dimensions.of(8.dp, 4.dp),
+    )
+    return remember(label) {
+        DefaultCartesianMarker(
+            label = label,
+            guideline = LineComponent(
+                color = android.graphics.Color.LTGRAY,
+                thicknessDp = 1f
+            ),
+        )
+    }
+}
+
+@Composable
+fun ModelInsightCard(title: String, content: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFF005EA4)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(modifier = Modifier.padding(20.dp), verticalAlignment = Alignment.Top) {
+            Surface(
+                modifier = Modifier.size(48.dp),
+                shape = RoundedCornerShape(8.dp),
+                color = Color.White.copy(alpha = 0.2f)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.idea),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = Color.White
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = content,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.85f),
+                    lineHeight = 18.sp
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GrafikScreenPreview() {
+    CovidPredictTheme {
+        GrafikScreen(viewModel = GrafikViewModel())
     }
 }

--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/PrediksiScreen.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/ui/screen/PrediksiScreen.kt
@@ -1,34 +1,471 @@
 package com.app.covidpredict.ui.screen
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.animation.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.app.covidpredict.R
+import com.app.covidpredict.theme.CovidPredictTheme
 import com.app.covidpredict.viewmodels.PrediksiViewModel
+import java.util.Locale
 
 @Composable
 fun PrediksiScreen(viewModel: PrediksiViewModel) {
-    val prediksi by viewModel.prediksi.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Prediksi")
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Text(prediksi)
-
-        Button(onClick = {
-            viewModel.generatePrediksi()
-        }) {
-            Text("Generate Prediksi")
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF8FBFE)),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            PrediksiHeader()
         }
+
+        item {
+            PredictionForm(
+                selectedRegion = uiState.selectedRegion,
+                regions = uiState.regions,
+                predictionDays = uiState.predictionDays,
+                alpha = uiState.alpha,
+                isLoading = uiState.isLoading,
+                isError = uiState.isError,
+                onAlphaChange = { viewModel.onAlphaChange(it) },
+                onRegionChange = { viewModel.onRegionChange(it) },
+                onDaysChange = { viewModel.onDaysChange(it) },
+                onProcess = { viewModel.calculatePrediction() }
+            )
+        }
+
+        item {
+            Text(
+                text = "Hasil Prediksi",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color(0xFF021F29)
+            )
+        }
+
+        item {
+            EstimationResultCard(
+                estimatedCases = if (uiState.isLoading) "..." else uiState.estimatedCases,
+                trendStatus = if (uiState.isLoading) "Menghitung..." else uiState.trendStatus
+            )
+        }
+
+        item {
+            PredictionStatCard(
+                label = "Interval Kepercayaan",
+                value = if (uiState.isLoading) "..." else uiState.confidenceInterval
+            )
+        }
+
+        item {
+            PredictionStatCard(
+                label = "Rata-rata Error Absolut (MAE)",
+                value = if (uiState.isLoading) "..." else uiState.avgError
+            )
+        }
+
+        item {
+            MethodologySection()
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+fun PrediksiHeader() {
+    Column {
+        Text(
+            text = "Analisis Prediksi",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.ExtraBold,
+            color = Color(0xFF021F29)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Atur parameter untuk model penghalusan klinis guna memperkirakan lintasan transmisi.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.Gray,
+            lineHeight = 20.sp
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PredictionForm(
+    selectedRegion: String,
+    regions: List<String>,
+    predictionDays: String,
+    alpha: Float,
+    isLoading: Boolean,
+    isError: Boolean,
+    onAlphaChange: (Float) -> Unit,
+    onRegionChange: (String) -> Unit,
+    onDaysChange: (String) -> Unit,
+    onProcess: () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val haptic = LocalHapticFeedback.current
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                "Pilih Wilayah",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF021F29)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Box {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { expanded = true },
+                    shape = RoundedCornerShape(8.dp),
+                    color = Color(0xFFEBF6FF)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            selectedRegion,
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color(0xFF021F29)
+                        )
+                        Icon(
+                            painter = painterResource(id = R.drawable.dropdown),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = Color.Gray
+                        )
+                    }
+                }
+
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                    modifier = Modifier.fillMaxWidth(0.8f)
+                ) {
+                    regions.forEach { region ->
+                        DropdownMenuItem(
+                            text = { Text(region) },
+                            onClick = {
+                                onRegionChange(region)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                "Cakupan Prediksi (Hari)",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF021F29)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            TextField(
+                value = predictionDays,
+                onValueChange = onDaysChange,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("1-30 hari") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color(0xFFEBF6FF),
+                    unfocusedContainerColor = Color(0xFFEBF6FF),
+                    focusedIndicatorColor = if (isError) Color.Red else MaterialTheme.colorScheme.primary,
+                    unfocusedIndicatorColor = if (isError) Color.Red else Color.Transparent
+                ),
+                shape = RoundedCornerShape(8.dp),
+                singleLine = true,
+                isError = isError
+            )
+
+            if (isError) {
+                Text(
+                    "Masukkan nilai antara 1-30 hari",
+                    color = Color.Red,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Cakupan jangka pendek (7-14 hari) menawarkan reliabilitas statistik yang lebih tinggi.",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.Gray
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                "Faktor Penghalusan (Alpha)",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF021F29)
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Slider(
+                    value = alpha,
+                    onValueChange = {
+                        onAlphaChange(it)
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    },
+                    modifier = Modifier.weight(1f),
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                        inactiveTrackColor = Color.LightGray.copy(alpha = 0.5f)
+                    )
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Surface(
+                    color = Color(0xFFEBF6FF),
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(
+                        text = String.format(Locale.getDefault(), "%.1f", alpha),
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = onProcess,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = RoundedCornerShape(8.dp),
+                enabled = !isLoading,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(id = R.drawable.chart_bar),
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        "Proses Prediksi",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EstimationResultCard(estimatedCases: String, trendStatus: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFCDE8F9).copy(alpha = 0.7f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Icon(
+                painter = painterResource(id = R.drawable.chart_line),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(200.dp)
+                    .offset(x = 30.dp),
+                tint = Color.Gray.copy(alpha = 0.2f)
+            )
+
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    "ESTIMASI PREDIKSI",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AnimatedContent(
+                        targetState = estimatedCases,
+                        transitionSpec = {
+                            (slideInVertically { height -> height } + fadeIn()).togetherWith(
+                                slideOutVertically { height -> -height } + fadeOut())
+                        },
+                        label = "estimatedCasesAnimation"
+                    ) { targetCases ->
+                        Text(
+                            text = targetCases,
+                            style = MaterialTheme.typography.headlineLarge,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = Color(0xFF021F29),
+                            fontSize = 42.sp
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        "Prediksi Kasus Positif",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.DarkGray,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(
+                            id = if (trendStatus.contains("Penurunan")) R.drawable.trending_down else R.drawable.trending_up
+                        ),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = if (trendStatus.contains("Penurunan")) Color(0xFF126D27) else Color(0xFFB02528)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    AnimatedContent(
+                        targetState = trendStatus,
+                        transitionSpec = {
+                            (fadeIn() + slideInHorizontally { width -> width / 2 }).togetherWith(
+                                fadeOut() + slideOutHorizontally { width -> -width / 2 })
+                        },
+                        label = "trendStatusAnimation"
+                    ) { targetTrend ->
+                        Text(
+                            text = targetTrend,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = if (targetTrend.contains("Penurunan")) Color(0xFF126D27) else Color(0xFFB02528),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PredictionStatCard(label: String, value: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.Gray,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color(0xFF021F29)
+            )
+        }
+    }
+}
+
+@Composable
+fun MethodologySection() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = Color(0xFFEBF6FF).copy(alpha = 0.8f)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    "Metodologi SES",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val annotatedString = buildAnnotatedString {
+                append("Metode ")
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append("Single Exponential Smoothing (SES)")
+                }
+                append(" adalah teknik peramalan deret waktu untuk data univariat. Ini menggunakan rata-rata bergerak berbobot di mana bobot berkurang secara eksponensial seiring bertambahnya usia observasi. Pendekatan ini sangat efektif untuk data epidemiologi di mana tren terkini (yang diatur oleh Faktor Penghalusan α) lebih representatif untuk hasil masa depan segera dibandingkan dengan puncak historis.")
+            }
+
+            Text(
+                text = annotatedString,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.DarkGray,
+                lineHeight = 18.sp
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PrediksiScreenPreview() {
+    CovidPredictTheme {
+        PrediksiScreen(viewModel = PrediksiViewModel())
     }
 }

--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/GrafikViewModel.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/GrafikViewModel.kt
@@ -3,10 +3,65 @@ package com.app.covidpredict.viewmodels
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class ChartPoint(val label: String, val actual: Float, val prediction: Float)
+
+data class GrafikUiState(
+    val selectedTab: Int = 0, // 0: Harian, 1: Mingguan, 2: Bulanan
+    val selectedRegion: String = "Nasional",
+    val regions: List<String> = listOf(
+        "Nasional", "Aceh", "Bali", "Banten", "Bengkulu", "DKI Jakarta",
+        "Daerah Istimewa Yogyakarta", "Gorontalo", "Jambi", "Jawa Barat",
+        "Jawa Tengah", "Jawa Timur", "Kalimantan Barat", "Kalimantan Selatan",
+        "Kalimantan Tengah", "Kalimantan Timur", "Kalimantan Utara",
+        "Kepulauan Bangka Belitung", "Kepulauan Riau", "Lampung", "Maluku",
+        "Maluku Utara", "Nusa Tenggara Barat", "Nusa Tenggara Timur",
+        "Papua", "Papua Barat", "Riau", "Sulawesi Barat", "Sulawesi Selatan",
+        "Sulawesi Tengah", "Sulawesi Tenggara", "Sulawesi Utara",
+        "Sumatera Barat", "Sumatera Selatan", "Sumatera Utara"
+    ),
+    val avgError: String = "-2.4%",
+    val insightTitle: String = "Wawasan Model",
+    val insightText: String = "Prediksi menunjukkan dataran 15% di sektor utara karena peningkatan kepadatan vaksinasi. Data aktual mencerminkan tren ini dengan fidelitas tinggi.",
+    val chartData: List<ChartPoint> = listOf(
+        ChartPoint("Mon", 10f, 12f),
+        ChartPoint("Tue", 15f, 14f),
+        ChartPoint("Wed", 25f, 24f),
+        ChartPoint("Thu", 20f, 22f),
+        ChartPoint("Fri", 18f, 19f),
+        ChartPoint("Sat", 15f, 16f),
+        ChartPoint("Sun", 30f, 28f)
+    )
+)
 
 class GrafikViewModel : ViewModel() {
-    private val _grafikData = MutableStateFlow(
-        listOf(10, 20, 30, 25, 40)
-    )
-    val grafikData: StateFlow<List<Int>> = _grafikData
+    private val _uiState = MutableStateFlow(GrafikUiState())
+    val uiState: StateFlow<GrafikUiState> = _uiState.asStateFlow()
+
+    fun selectTab(index: Int) {
+        _uiState.value = _uiState.value.copy(
+            selectedTab = index,
+            chartData = generateMockData(index)
+        )
+    }
+
+    fun selectRegion(region: String) {
+        _uiState.value = _uiState.value.copy(
+            selectedRegion = region,
+            chartData = generateMockData(_uiState.value.selectedTab)
+        )
+    }
+
+    private fun generateMockData(tabIndex: Int): List<ChartPoint> {
+        val labels = when (tabIndex) {
+            0 -> listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+            1 -> listOf("W1", "W2", "W3", "W4", "W5", "W6", "W7")
+            else -> listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul")
+        }
+        return labels.map {
+            val actual = (10..50).random().toFloat()
+            ChartPoint(it, actual, actual + (-5..5).random())
+        }
+    }
 }

--- a/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/PrediksiViewModel.kt
+++ b/frontend/android-app/app/src/main/java/com/app/covidpredict/viewmodels/PrediksiViewModel.kt
@@ -1,14 +1,104 @@
 package com.app.covidpredict.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.Locale
+import kotlin.math.abs
+
+data class PrediksiUiState(
+    val selectedRegion: String = "Nasional",
+    val regions: List<String> = listOf(
+        "Nasional", "Aceh", "Bali", "Banten", "Bengkulu", "DKI Jakarta",
+        "Daerah Istimewa Yogyakarta", "Gorontalo", "Jambi", "Jawa Barat",
+        "Jawa Tengah", "Jawa Timur", "Kalimantan Barat", "Kalimantan Selatan",
+        "Kalimantan Tengah", "Kalimantan Timur", "Kalimantan Utara",
+        "Kepulauan Bangka Belitung", "Kepulauan Riau", "Lampung", "Maluku",
+        "Maluku Utara", "Nusa Tenggara Barat", "Nusa Tenggara Timur",
+        "Papua", "Papua Barat", "Riau", "Sulawesi Barat", "Sulawesi Selatan",
+        "Sulawesi Tengah", "Sulawesi Tenggara", "Sulawesi Utara",
+        "Sumatera Barat", "Sumatera Selatan", "Sumatera Utara"
+    ),
+    val predictionDays: String = "14",
+    val alpha: Float = 0.7f,
+    val estimatedCases: String = "-",
+    val trendStatus: String = "Menunggu perhitungan...",
+    val confidenceInterval: String = "-",
+    val avgError: String = "-",
+    val isLoading: Boolean = false,
+    val isError: Boolean = false
+)
 
 class PrediksiViewModel : ViewModel() {
-    private val _prediksi = MutableStateFlow("Belum ada prediksi")
-    val prediksi: StateFlow<String> = _prediksi
+    private val _uiState = MutableStateFlow(PrediksiUiState())
+    val uiState: StateFlow<PrediksiUiState> = _uiState.asStateFlow()
 
-    fun generatePrediksi() {
-        _prediksi.value = "Kasus akan meningkat 10%"
+    // Mock dataset untuk simulasi (Kasus harian 10 hari terakhir)
+    private val mockTimeSeriesData = listOf(1200.0, 1150.0, 1300.0, 1250.0, 1400.0, 1350.0, 1500.0, 1450.0, 1600.0, 1550.0)
+
+    fun onAlphaChange(newAlpha: Float) {
+        _uiState.value = _uiState.value.copy(alpha = newAlpha)
+    }
+
+    fun onRegionChange(region: String) {
+        _uiState.value = _uiState.value.copy(selectedRegion = region)
+    }
+
+    fun onDaysChange(days: String) {
+        // Hanya izinkan angka
+        if (days.all { it.isDigit() } || days.isEmpty()) {
+            _uiState.value = _uiState.value.copy(predictionDays = days)
+        }
+    }
+
+    fun calculatePrediction() {
+        val daysInput = _uiState.value.predictionDays.toIntOrNull() ?: 0
+
+        // Validasi 1-30 hari
+        if (daysInput !in 1..30) {
+            _uiState.value = _uiState.value.copy(isError = true)
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, isError = false)
+
+            // Simulasi loading/kalkulasi
+            delay(1500)
+
+            val alpha = _uiState.value.alpha
+            val data = mockTimeSeriesData
+
+            // Logika Single Exponential Smoothing (SES)
+            // S_t = alpha * Y_t + (1 - alpha) * S_{t-1}
+            var level = data[0]
+            val errors = mutableListOf<Double>()
+
+            for (i in 1 until data.size) {
+                val forecast = level
+                val actual = data[i]
+                errors.add(abs(actual - forecast))
+                level = alpha * actual + (1 - alpha) * level
+            }
+
+            // Hasil peramalan SES adalah nilai 'level' terakhir
+            val forecastResult = level.toInt()
+            val mae = if (errors.isNotEmpty()) errors.average() else 0.0
+
+            // Mock Confidence Interval berdasarkan MAE
+            val ciValue = 100 - (mae / forecastResult * 100).coerceIn(0.0, 10.0)
+
+            _uiState.value = _uiState.value.copy(
+                isLoading = false,
+                estimatedCases = String.format(Locale.getDefault(), "%,d", forecastResult),
+                avgError = String.format(Locale.getDefault(), "%.2f%%", (mae / forecastResult * 100)),
+                confidenceInterval = String.format(Locale.getDefault(), "%.1f%%", ciValue),
+                trendStatus = if (forecastResult > data.last()) "Potensi Kenaikan" else "Potensi Penurunan"
+            )
+        }
     }
 }

--- a/frontend/android-app/app/src/main/res/drawable/chart_bar.xml
+++ b/frontend/android-app/app/src/main/res/drawable/chart_bar.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="#000000" android:pathData="M21.691,4.887C21.588,3.546 20.557,2.412 19.113,2.309C17.052,2.103 14.165,2 12,2C9.835,2 6.948,2.103 4.887,2.309C4.165,2.309 3.546,2.619 3.134,3.134C2.722,3.649 2.412,4.165 2.309,4.887C2.103,6.948 2,9.835 2,12C2,14.165 2.206,17.052 2.309,19.113C2.412,20.454 3.443,21.588 4.887,21.691C6.948,21.897 9.835,22 12,22C14.165,22 17.052,21.794 19.113,21.691C20.454,21.588 21.588,20.557 21.691,19.113C21.897,17.052 22,14.165 22,12C22,9.835 21.897,6.948 21.691,4.887ZM8.701,16.124C8.701,16.536 8.392,16.948 7.876,16.948C7.361,16.948 7.052,16.536 7.052,16.124V13.031C7.052,12.619 7.361,12.206 7.876,12.206C8.392,12.206 8.701,12.516 8.701,13.031V16.124ZM12.825,16.124C12.825,16.536 12.516,16.948 12,16.948C11.484,16.948 11.175,16.639 11.175,16.124V9.938C11.175,9.526 11.484,9.113 12,9.113C12.516,9.113 12.825,9.423 12.825,9.938V16.124ZM16.948,16.124C16.948,16.536 16.639,16.948 16.124,16.948C15.608,16.948 15.299,16.639 15.299,16.124V6.845C15.299,6.433 15.608,6.021 16.124,6.021C16.639,6.021 16.948,6.33 16.948,6.845V16.124Z"/>
+    
+</vector>

--- a/frontend/android-app/app/src/main/res/drawable/chart_line.xml
+++ b/frontend/android-app/app/src/main/res/drawable/chart_line.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="#000000" android:fillType="evenOdd" android:pathData="M5.823,14.177C5.937,14.428 6,14.707 6,15C6,16.105 5.105,17 4,17C2.895,17 2,16.105 2,15C2,13.895 2.895,13 4,13C4.293,13 4.572,13.063 4.823,13.177L7.177,10.823C7.063,10.572 7,10.293 7,10C7,8.895 7.895,8 9,8C10.105,8 11,8.895 11,10C11,10.293 10.937,10.572 10.823,10.823L13.177,13.177C13.428,13.063 13.707,13 14,13C14.293,13 14.572,13.063 14.823,13.177L18.177,9.823C18.063,9.572 18,9.293 18,9C18,7.895 18.895,7 20,7C21.105,7 22,7.895 22,9C22,10.105 21.105,11 20,11C19.707,11 19.428,10.937 19.177,10.823L15.823,14.177C15.937,14.428 16,14.707 16,15C16,16.105 15.105,17 14,17C12.895,17 12,16.105 12,15C12,14.707 12.063,14.428 12.177,14.177L9.823,11.823C9.572,11.937 9.293,12 9,12C8.707,12 8.428,11.937 8.177,11.823L5.823,14.177Z" android:strokeColor="#00000000" android:strokeWidth="1"/>
+    
+</vector>

--- a/frontend/android-app/app/src/main/res/drawable/idea.xml
+++ b/frontend/android-app/app/src/main/res/drawable/idea.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="472.62" android:viewportWidth="472.62" android:width="24dp">
+      
+    <path android:fillColor="#000000" android:pathData="M177.53,452.92h117.58v19.69h-117.58z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M158.62,412.38h155.33v19.69h-155.33z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M228.44,0.19C146.55,4.05 78.94,70.85 74.14,152.7c-2.27,38.67 9.04,74.56 29.58,103.46c27.48,38.67 45.13,83.3 48.57,130.24h167.94c2.94,-45.3 17.59,-89.48 45.24,-125.59c20.88,-27.27 33.3,-61.34 33.3,-98.36C398.76,70.12 321.74,-4.22 228.44,0.19z"/>
+    
+</vector>


### PR DESCRIPTION
## Deskripsi
Menambahkan halaman Prediksi untuk melakukan simulasi prediksi kasus positif berdasarkan wilayah, jumlah hari prediksi, dan nilai faktor penghalusan alpha.

## Perubahan
- Menambahkan UI Prediction Screen menggunakan Jetpack Compose
- Menambahkan dropdown pemilihan wilayah
- Menambahkan input cakupan prediksi 1–30 hari
- Menambahkan slider faktor penghalusan alpha
- Menambahkan tombol proses prediksi dengan loading state
- Menampilkan hasil estimasi prediksi kasus positif
- Menampilkan status tren kenaikan/penurunan
- Menampilkan interval kepercayaan dan rata-rata error absolut
- Menambahkan penjelasan metodologi Single Exponential Smoothing (SES)
- Menghubungkan screen dengan PrediksiViewModel menggunakan StateFlow